### PR TITLE
データ再投入時の削除が失敗する不具合を修正

### DIFF
--- a/src/Evolve/Model/ModelBase.php
+++ b/src/Evolve/Model/ModelBase.php
@@ -750,8 +750,8 @@ class ModelBase extends Model {
 	protected static function _repopulateAll($source)
 	{
 		$static = new static();
-		$query = "DELETE FROM $static->getClass()";
-		$static->getModelsManager()->execute($query);
+		$query = "DELETE FROM {$static->getClass()}";
+		$static->getModelsManager()->executeQuery($query);
 		foreach ($source as $data) {
 			$data = Ax::x($data)->filter(function($v, $k) {
 				list ($key) = explode(')', $k);


### PR DESCRIPTION
## 問題

- データ再投入時にエラーが出て何も起こらない

## 修正箇所・理由

- 文字列内でそのままメソッドを書いてもプロパティとして評価されてしまうため、 ブレース `{}` で囲った
- 存在しないメソッド `execute` を、元々意図していたであろう存在するメソッド `executeQuery` に変更

## 備考

-  CityHC のソートヒントのインポート時に気付いた
