### PR TITLE
JSON 変換時に特定のカラムを無視するようにした

### DIFF
--- a/src/Evolve/Model/ModelBase.php
+++ b/src/Evolve/Model/ModelBase.php
@@ -550,16 +550,20 @@ class ModelBase extends Model {
 
 	/**
 	 * JSON 変換用の配列を取得する
+	 * @param array $ignored_columns 変換後の JSON に含めないカラム名
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function pullArray()
+	public function pullArray($ignored_columns = [])
 	{
 		$metaData = $this->getModelsMetaData();
 		$attributes = $metaData->getAttributes($this);
 		$columnMap = $metaData->getColumnMap($this);
 		$data = [];
 		foreach ($attributes as $attribute) {
+			if (in_array($attribute, $ignored_columns)) {
+				continue;
+			}
 			$field = $attribute;
 			if (is_array($columnMap) and isset($columnMap[$attribute])) {
 				$field = $columnMap[$attribute];


### PR DESCRIPTION
## 目的

- JSON 変換時に特定のカラムを無視できるようにする

## 背景

- City-HC で大量の API が必要になった
- `password` や `create_ts` など、不要な情報を外に出さないようにしたい

## やったこと

- Model クラスを JSON に変換するメソッドに、無視するカラムのリストを引数として渡せるようにした
- JSON への変換時に、追加された引数に含まれているカラムを JSON に含めないようにした

## 検証

```php
>>> use App\Models\Members
>>> $m = new Members()
=> App\Models\Members {#340}
>>> $m->pullArray()
=> [
     "id" => 0,
     "type" => "parent",
     "status" => null,
     "login" => null,
     "password" => null,
     "language" => "ja",
     "name" => null,
     "email" => null,
     "gender" => "unknown",
     "birthday" => null,
     "marital_status" => null,
     "reside_area_id" => null,
     "mail_returned" => 0,
     "created_ts" => 0,
   ]
>>> $m->pullArray(["created_ts", "password"])
=> [
     "id" => 0,
     "type" => "parent",
     "status" => null,
     "login" => null,
     "language" => "ja",
     "name" => null,
     "email" => null,
     "gender" => "unknown",
     "birthday" => null,
     "marital_status" => null,
     "reside_area_id" => null,
     "mail_returned" => 0,
   ]
>>> 
```
