### PR TITLE
テスト時に簡単にセッションが切れてしまいがちな問題の対応

### DIFF
--- a/src/Evolve/Security/Auth.php
+++ b/src/Evolve/Security/Auth.php
@@ -23,7 +23,7 @@ class Auth extends Injectable {
 	/** セッション上に認証情報への参照(indexer_id)を保存するためのデフォルトキー */
 	const DEFAULT_SESSION_KEY = '_auth';
 	/** ユーザあたりの最大セッション数 */
-	const USER_MAX_SESSIONS = 5;
+	const USER_MAX_SESSIONS = 10;
 	
 	/** @var UserInterface; */
 	protected $user;


### PR DESCRIPTION
## 問題

テスト時に複数端末でアクセスすることがあり、最大セッション数に達して勝手にログアウトしてしまう。

## やったこと

1 ユーザあたりの最大セッション数を増やした。
