### PR TITLE
Sx::replace の型注釈を実装に合わせる

### DIFF
--- a/src/Evolve/PrimitiveExtension/StringExtension.php
+++ b/src/Evolve/PrimitiveExtension/StringExtension.php
@@ -257,7 +257,7 @@ class StringExtension {
 	 * replace(array(string $from => string $to) $replacements, int $limit = PHP_MAX_INT)
 	 * replace(string $from, string $to, int $limit = PHP_MAX_INT)
 	 * 
-	 * @param string $from
+	 * @param string|array $from
 	 * @param string $to
 	 * @param int $limit
 	 * @param bool $ignore_case


### PR DESCRIPTION
`StringExtension::replace` メソッドの第一引数の型注釈を、実際に受け入れる型に合わせて `string|array` とした