### PR TITLE
数値範囲チェックバリデータのバグ修正

### DIFF
--- a/src/Evolve/View/TranslatedValidation.php
+++ b/src/Evolve/View/TranslatedValidation.php
@@ -328,7 +328,11 @@ class TranslatedValidation extends Validation {
 			$options['messageMaximum'] = $this->translate->minLength($maxValue);
 		}
 		if ($options->any()) {
-			$this->add($attribute, new Between($options->unwrap()));
+			$this->add($attribute, new Between([
+				"minimum" => $options['minimum'],
+				"maximum" => $options['maximum'],
+				"message" => $options['messageMinimum'] . $options['messageMaximum'],
+			]));
 		}
 		$this->setLabel($attribute, $label);
 		return $this;

--- a/src/Evolve/View/TranslatedValidation.php
+++ b/src/Evolve/View/TranslatedValidation.php
@@ -329,9 +329,9 @@ class TranslatedValidation extends Validation {
 		}
 		if ($options->any()) {
 			$this->add($attribute, new Between([
-				"minimum" => $options['minimum'],
-				"maximum" => $options['maximum'],
-				"message" => $options['messageMinimum'] . $options['messageMaximum'],
+				'minimum' => $options['minimum'],
+				'maximum' => $options['maximum'],
+				'message' => $options['messageMinimum'] . $options['messageMaximum'],
 			]));
 		}
 		$this->setLabel($attribute, $label);

--- a/src/Evolve/View/TranslatedValidation.php
+++ b/src/Evolve/View/TranslatedValidation.php
@@ -325,7 +325,7 @@ class TranslatedValidation extends Validation {
 		}
 		if (!is_null($maxValue)) {
 			$options['maximum'] = $maxValue;
-			$options['messageMaximum'] = $this->translate->minLength($maxValue);
+			$options['messageMaximum'] = $this->translate->maxValue($maxValue);
 		}
 		if ($options->any()) {
 			$this->add($attribute, new Between([


### PR DESCRIPTION
数値範囲チェックで NG だった際に、`体重は1から100で入力してください。` といったエラーメッセージが期待されると思います。

[Between バリデータのドキュメント](https://teruchiphalcon-docs.readthedocs.io/ja/latest/api/Phalcon_Validation_Validator_Between.html)にもあるのですが、
- `minimum`
- `maximum`
- `message`

が設定された配列をコンストラクタで期待しており、minimum, maximum は渡っていましたが、messageが渡っておらず、日本語翻訳された `1から10` といったメッセージが利用側で扱えませんでした。

その結果、
https://github.com/milabo/city_hc/blob/master/web/app/components/Forms/GrowthRecordFrom.php#L73-L75
こういったワークアラウンドが生まれていたので、根本解決したいという意図の PR です。