### PR TITLE
入れ子になった配列を平坦化するメソッドを追加する

### DIFF
--- a/src/Evolve/PrimitiveExtension/ArrayExtension.php
+++ b/src/Evolve/PrimitiveExtension/ArrayExtension.php
@@ -402,7 +402,41 @@ class ArrayExtension implements \Countable, \Iterator, \ArrayAccess {
 		}
 		return self::x($ret);
 	}
-	
+
+	/**
+	 * 配列を畳み込む
+	 * @param callable $callback
+	 *   第一引数には畳み込みの途中結果、第二引数には要素が渡され、畳み込み結果を返す関数。
+	 * @param mixed $initialValue 畳み込みの初期値
+	 * @return mixed
+	 */
+	public function fold($callback, $initialValue)
+	{
+		$ret = $initialValue;
+		foreach ($this->array as $item) {
+			$ret = $callback($ret, $item);
+		}
+		return $ret;
+	}
+
+	/**
+	 * 入れ子になった配列を平坦化する。
+	 * 多重に入れ子になっていても再帰的に平坦化しない。
+	 * @return ArrayExtension
+	 */
+	public function flatten()
+	{
+		$flattened = $this->fold(function ($acc, $value) {
+			if (is_array($value)) {
+				return array_merge($acc, $value);
+			} else {
+				$acc[] = $value;
+				return $acc;
+			}
+		}, []);
+		return static::x($flattened);
+	}
+
 	#endregion
 	
 	#region convert

--- a/tests/Evolve/PrimitiveExtension/ArrayTest.php
+++ b/tests/Evolve/PrimitiveExtension/ArrayTest.php
@@ -87,10 +87,10 @@ class ArrayTest extends UnitTestCase {
 
 	public function testFold()
 	{
-		$actual = Ax::x(['a', 'b', 'c'])
+		$actual = Ax::x(['b', 'c'])
 			->fold(function ($acc, $value) {
 				return $acc . $value;
-			}, '');
+			}, 'a');
 		$this->assertEquals('abc', $actual);
 	}
 

--- a/tests/Evolve/PrimitiveExtension/ArrayTest.php
+++ b/tests/Evolve/PrimitiveExtension/ArrayTest.php
@@ -84,6 +84,21 @@ class ArrayTest extends UnitTestCase {
 			'E' => 'E:fourth'
 		], $arr2->unwrap());
 	}
+
+	public function testFold()
+	{
+		$actual = Ax::x(['a', 'b', 'c'])
+			->fold(function ($acc, $value) {
+				return $acc . $value;
+			}, '');
+		$this->assertEquals('abc', $actual);
+	}
+
+	public function testFlatten()
+	{
+		$actual = Ax::x(['a', ['b', 'c'], ['d'], 'e', [['f'], ['g']]])->flatten()->toList();
+		$this->assertEquals(['a', 'b', 'c', 'd', 'e', ['f'], ['g']], $actual);
+	}
 	
 	public function testSearch()
 	{


### PR DESCRIPTION
こういうことがしたい。

```php
Ax::x([
    ['a', 'b'],
    ['c', 'd', 'e'],
])->flatten()->toList();
// => ['a', 'b', 'c', 'd', 'e']
```

`flatten` を作るときに畳み込みができないことに気付いたので `fold` メソッドも作った。