### PR TITLE
fix: 継承してメールを送信しないSenderを作りたいのでインターフェースを作成

### DIFF
--- a/src/Evolve/Mail/Sender.php
+++ b/src/Evolve/Mail/Sender.php
@@ -21,58 +21,58 @@ class Sender {
 	const MAIL_ENCODING = 'ISO-2022-JP';
 
 	/** @var \Net_SMTP */
-	private $smtp = null;
+	protected $smtp = null;
 
 	/** @var string */
-	private $host;
+	protected $host;
 
 	/** @var string */
-	private $user = null;
+	protected $user = null;
 
 	/** @var string */
-	private $password = null;
+	protected $password = null;
 
 	/** @var bool */
-	private $is_connected = false;
+	protected $is_connected = false;
 
 	/** @var array|string */
-	private $sender_address;
+	protected $sender_address;
 
 	/** @var string */
-	private $subject;
+	protected $subject;
 
 	/** @var array|string */
-	private $receiver_addresses;
+	protected $receiver_addresses;
 
 	/** @var array|string */
-	private $cc_addresses;
+	protected $cc_addresses;
 
 	/** @var array|string */
-	private $bcc_addresses;
+	protected $bcc_addresses;
 
 	/** @var string 返信先アドレス */
-	private $reply_to;
+	protected $reply_to;
 
 	/** @var string エラー返送先アドレス */
-	private $return_path;
+	protected $return_path;
 
 	/** @var \Phalcon\Mvc\View\Engine\Volt */
-	private $volt;
+	protected $volt;
 
 	/** @var string */
-	private $template_dir;
+	protected $template_dir;
 
 	/** @var \Phalcon\Logger\AdapterInterface */
-	private $logger;
+	protected $logger;
 
 	/** @var string[]|array */
-	private $additional_headers = array();
+	protected $additional_headers = array();
 
 	/** @var string[]|array */
-	private $last_headers;
+	protected $last_headers;
 
 	/** @var string */
-	private	$last_body;
+	protected	$last_body;
 
 	/**
 	 * @param array $settings
@@ -460,7 +460,7 @@ class Sender {
 	 * @param array $headers (REF) The list of the mail headers to fill up.
 	 * @param mixed $param The parameter of Mail - TO, CC, BCC.
 	 */
-	private static function procParam($headername, array &$recipients, array &$headers, $param) {
+	protected static function procParam($headername, array &$recipients, array &$headers, $param) {
 		$headers[$headername] = "";
 		if (is_array($param)) {
 			$dlm = '';
@@ -484,7 +484,7 @@ class Sender {
 	 * @param string $subject The mail subject.
 	 * @return string The encoded subject.
 	 */
-	private static function encodeHeader($subject)
+	protected static function encodeHeader($subject)
 	{
 		$subject = mb_convert_encoding($subject, self::MAIL_ENCODING, self::INTERNAL_ENCODING);
 		mb_internal_encoding(self::MAIL_ENCODING);

--- a/src/Evolve/Mail/Sender.php
+++ b/src/Evolve/Mail/Sender.php
@@ -21,58 +21,58 @@ class Sender {
 	const MAIL_ENCODING = 'ISO-2022-JP';
 
 	/** @var \Net_SMTP */
-	protected $smtp = null;
+	private $smtp = null;
 
 	/** @var string */
-	protected $host;
+	private $host;
 
 	/** @var string */
-	protected $user = null;
+	private $user = null;
 
 	/** @var string */
-	protected $password = null;
+	private $password = null;
 
 	/** @var bool */
-	protected $is_connected = false;
+	private $is_connected = false;
 
 	/** @var array|string */
-	protected $sender_address;
+	private $sender_address;
 
 	/** @var string */
-	protected $subject;
+	private $subject;
 
 	/** @var array|string */
-	protected $receiver_addresses;
+	private $receiver_addresses;
 
 	/** @var array|string */
-	protected $cc_addresses;
+	private $cc_addresses;
 
 	/** @var array|string */
-	protected $bcc_addresses;
+	private $bcc_addresses;
 
 	/** @var string 返信先アドレス */
-	protected $reply_to;
+	private $reply_to;
 
 	/** @var string エラー返送先アドレス */
-	protected $return_path;
+	private $return_path;
 
 	/** @var \Phalcon\Mvc\View\Engine\Volt */
-	protected $volt;
+	private $volt;
 
 	/** @var string */
-	protected $template_dir;
+	private $template_dir;
 
 	/** @var \Phalcon\Logger\AdapterInterface */
-	protected $logger;
+	private $logger;
 
 	/** @var string[]|array */
-	protected $additional_headers = array();
+	private $additional_headers = array();
 
 	/** @var string[]|array */
-	protected $last_headers;
+	private $last_headers;
 
 	/** @var string */
-	protected	$last_body;
+	private	$last_body;
 
 	/**
 	 * @param array $settings
@@ -460,7 +460,7 @@ class Sender {
 	 * @param array $headers (REF) The list of the mail headers to fill up.
 	 * @param mixed $param The parameter of Mail - TO, CC, BCC.
 	 */
-	protected static function procParam($headername, array &$recipients, array &$headers, $param) {
+	private static function procParam($headername, array &$recipients, array &$headers, $param) {
 		$headers[$headername] = "";
 		if (is_array($param)) {
 			$dlm = '';
@@ -484,7 +484,7 @@ class Sender {
 	 * @param string $subject The mail subject.
 	 * @return string The encoded subject.
 	 */
-	protected static function encodeHeader($subject)
+	private static function encodeHeader($subject)
 	{
 		$subject = mb_convert_encoding($subject, self::MAIL_ENCODING, self::INTERNAL_ENCODING);
 		mb_internal_encoding(self::MAIL_ENCODING);

--- a/src/Evolve/Mail/Sender.php
+++ b/src/Evolve/Mail/Sender.php
@@ -15,7 +15,7 @@ require_once 'Mail/mime.php';
  *
  * @package Phalcon\Evolve\Mail
  */
-class Sender {
+class Sender implements SenderInterface {
 
 	const INTERNAL_ENCODING = 'UTF-8';
 	const MAIL_ENCODING = 'ISO-2022-JP';

--- a/src/Evolve/Mail/SenderInterface.php
+++ b/src/Evolve/Mail/SenderInterface.php
@@ -1,0 +1,171 @@
+<?php
+
+
+namespace Phalcon\Evolve\Mail;
+
+
+interface SenderInterface
+{
+	/**
+	 * SMTP サーバに接続する
+	 * @param string $user
+	 * @param string $password
+	 * @return bool
+	 * @throws \ErrorException
+	 */
+	public function connect($user = null, $password = null);
+
+	/**
+	 * SMTP サーバから切断する
+	 */
+	public function close();
+
+	/**
+	 * @param \Phalcon\Logger\AdapterInterface $logger
+	 * @return self $this
+	 */
+	public function setLogger($logger);
+
+	/**
+	 * 送信元メールアドレス
+	 * ハッシュとして設定することで、署名を付与できます。
+	 * 例: array('鈴木 健太' => 'sukobuto@gmail.com')
+	 *
+	 * @param string|array $sender_address
+	 * @return self $this
+	 */
+	public function setSenderAddress($sender_address);
+
+	/**
+	 * @param string $subject
+	 * @return self $this
+	 */
+	public function setSubject($subject);
+
+	public function getSubject();
+
+	/**
+	 * @param string $name
+	 * @param string $value
+	 * @return self $this
+	 */
+	public function setHeader($name, $value);
+
+	/**
+	 * @param array $headers
+	 * @return $this
+	 */
+	public function setHeaders($headers);
+
+	/**
+	 * @param string $name
+	 * @return self $this
+	 */
+	public function removeHeader($name);
+
+	/**
+	 * @return $this
+	 */
+	public function clearHeaders();
+
+	public function getLastHeaders();
+
+	/**
+	 * @return string
+	 */
+	public function getLastHeadersString();
+
+	public function getLastBody();
+
+	/**
+	 * 送信先アドレスを設定する
+	 * ハッシュとして設定することで、署名を付与できます。
+	 *
+	 * @param string|array $receiver_addresses
+	 * @return self $this
+	 */
+	public function setReceiverAddresses($receiver_addresses);
+
+	/**
+	 * @return array|string[]
+	 */
+	public function getReceiverAddresses();
+
+	/**
+	 * CCアドレスを設定する
+	 * ハッシュとして設定することで、署名を付与できます。
+	 *
+	 * @param string|array $cc_addresses
+	 * @return self $this
+	 */
+	public function setCcAddresses($cc_addresses);
+
+	/**
+	 * BCCアドレスを設定する
+	 * ハッシュとして設定することで、署名を付与できます。
+	 *
+	 * @param string|array $bcc_addresses
+	 * @return self $this
+	 */
+	public function setBccAddresses($bcc_addresses);
+
+	/**
+	 * 返信先アドレスを設定する
+	 *
+	 * @param string $reply_to
+	 * @return self $this
+	 */
+	public function setReplyTo($reply_to);
+
+	public function getReplyTo();
+
+	/**
+	 * 配送エラー返送先アドレスを設定する
+	 *
+	 * @param $return_path
+	 * @return self $this
+	 */
+	public function setReturnPath($return_path);
+
+	public function getReturnPath();
+
+	/**
+	 * テンプレートをコンパイルするための Volt を設定する
+	 *
+	 * @param \Phalcon\Mvc\View\Engine\Volt $voltService
+	 * @return self $this
+	 */
+	public function setVolt($voltService);
+
+	/**
+	 * メールテンプレートが格納されているディレクトリを設定する
+	 *
+	 * @param string $template_dir
+	 * @return self $this
+	 */
+	public function setTemplateDirectory($template_dir);
+
+	/**
+	 * 本文を送信
+	 * @param string $body
+	 * @param null|array $attachments
+	 * @return array 0:code(int), 1:message(string)
+	 * @throws \Exception
+	 */
+	public function send($body, $attachments = null);
+
+	/**
+	 * テンプレートを使って本文をレンダリングし送信
+	 * @param string $template_name
+	 * @param array $params
+	 * @return self $this
+	 */
+	public function sendRender($template_name, $params);
+
+	/**
+	 * @param $object
+	 * @return mixed
+	 */
+	public static function unwrapObject($object);
+
+}


### PR DESCRIPTION
## 目的（何を解決したいのか）

- メール送信をローカル環境で動くようにする
- `Sender` を継承したクラスを作り、ローカルではメールを送信せずログに出力するようにしたい

## 背景（どうしてこの変更の必要があるのか）

- 予診票再発行申請の改修で、申請時にメール送信をしているが connection refused で動かないためテストができない

## やったこと（目的とは分離して、実際に変更した内容）

- ~~`Sender` のメンバー変数を private にする~~
- interface を作って `Sender` に `implements` させた

## 備考

- https://github.com/milabo/city_hc/pull/839
