### PR TITLE
feat: CSV インポート時に形式チェックをするため lightAssign で getter を呼び出すようにした

### DIFF
--- a/src/Evolve/Model/ModelBase.php
+++ b/src/Evolve/Model/ModelBase.php
@@ -460,6 +460,8 @@ class ModelBase extends Model {
 		foreach ($data as $field => $value) {
 			if (empty($whiteList) or Ax::x($whiteList)->contains($field)) {
 				$this->_setValue($field, $value);
+				// 形式チェックのため getter 呼び出し
+				$this->_getValue($field, $value);
 			}
 		}
 		return $this;


### PR DESCRIPTION
## 問題
city-hc 管理画面で CSV をインポートする際に形式チェックがされておらず、データが入ってしまう。
間違いに気づいて再度 CSV をインポートしようとすると、 getter が呼ばれて形式チェックで落ちるため、インポートできないというトラップがある。

## 目的

CSV インポート時に形式チェックをするようにしたい。

## やったこと

- CSV からモデルに変換する`lightAssign` の中で `setter` だけでなく `getter` も呼ぶようにした

## 解決法に対する考察

- 本来であれば setter で形式チェックを入れるか、全て assign したあとに形式チェックを走らせるなどの方がスマートだが、それだと全てのモデルに必要なメソッドを追加したり、全てのフィールドを修正していく必要がある。
- 問題が発生する箇所は `TermDate` などオブジェクトクラスを使用している箇所なので、 getter が呼ばれた時に `new` して返すことが多いため `getter` を呼び出すようにしてみた。
- いくつあるか分からないが、 `TermDate` を使用するカラムの `setter` 全てに形式チェックを入れていくという手もある

## 管理画面 EventSlots
![スクリーンショット 2020-10-26 16 48 56](https://user-images.githubusercontent.com/3732626/97146415-2a369a00-17ab-11eb-9259-424d49c23154.png)

## 備考

似たような `FragmentedDateTime` の場合、想定する形式は `YYYY/mm/dd` だけど `YYYY-mm-dd` でインポートされると形式が認識されず空文字になる
