### PR TITLE
revert: lightAssign で getter を呼ぶのを差し戻し、 getter で引数必須のメソッドがあると落ちるため

### DIFF
--- a/src/Evolve/Model/ModelBase.php
+++ b/src/Evolve/Model/ModelBase.php
@@ -460,8 +460,6 @@ class ModelBase extends Model {
 		foreach ($data as $field => $value) {
 			if (empty($whiteList) or Ax::x($whiteList)->contains($field)) {
 				$this->_setValue($field, $value);
-				// 形式チェックのため getter 呼び出し
-				$this->_getValue($field);
 			}
 		}
 		return $this;


### PR DESCRIPTION
## 元 PullRequest

- https://github.com/milabo/phalcon-evolve/pull/13
- https://github.com/milabo/phalcon-evolve/pull/14

## 問題

getter で引数必須のメソッドがある場合、エラーになる。
影響範囲が大きすぎて、調査しきれない。

## やったこと

- `1.3.62` の状態に戻す

