### PR TITLE
feat: カンマ区切りの文字列をフィルターで配列にできるようにした

### DIFF
--- a/src/Evolve/Model/CsvDataAdapter.php
+++ b/src/Evolve/Model/CsvDataAdapter.php
@@ -23,7 +23,7 @@ class CsvDataAdapter {
 	const FILTER_DATE = 'date';
 	const FILTER_DATETIME2TS = 'datetime2ts'; // "Y-M-D H:i:s" -> timestamp
 	const FILTER_TS2DATETIME = 'ts2datetime'; // timestamp -> "Y-M-D H:i:s"
-	const FILTER_SEPARATED_COMMA = 'separated_comma';
+	const FILTER_SEPARATED_COMMA = 'separated_comma'; // "string1,string2" -> array["string1","string2"]
 
 	/**
 	 * @param $class

--- a/src/Evolve/Model/CsvDataAdapter.php
+++ b/src/Evolve/Model/CsvDataAdapter.php
@@ -23,7 +23,7 @@ class CsvDataAdapter {
 	const FILTER_DATE = 'date';
 	const FILTER_DATETIME2TS = 'datetime2ts'; // "Y-M-D H:i:s" -> timestamp
 	const FILTER_TS2DATETIME = 'ts2datetime'; // timestamp -> "Y-M-D H:i:s"
-	const FILTER_TAXONOMY_COMMA = 'taxonomy_comma';
+	const FILTER_SEPARATED_COMMA = 'separated_comma';
 
 	/**
 	 * @param $class
@@ -193,7 +193,7 @@ class CsvDataAdapter {
 					return $this->anyToTimestamp($value);
 				case self::FILTER_TS2DATETIME:
 					return $this->timestampToDatetime($value, "Y-m-d H:i:s");
-				case self::FILTER_TAXONOMY_COMMA:
+				case self::FILTER_SEPARATED_COMMA:
 					return Sx::x($value)->split(',', true);
 				default:
 					return call_user_func($filter, $value);

--- a/src/Evolve/Model/CsvDataAdapter.php
+++ b/src/Evolve/Model/CsvDataAdapter.php
@@ -23,6 +23,7 @@ class CsvDataAdapter {
 	const FILTER_DATE = 'date';
 	const FILTER_DATETIME2TS = 'datetime2ts'; // "Y-M-D H:i:s" -> timestamp
 	const FILTER_TS2DATETIME = 'ts2datetime'; // timestamp -> "Y-M-D H:i:s"
+	const FILTER_TAXONOMY_COMMA = 'taxonomy_comma';
 
 	/**
 	 * @param $class
@@ -192,6 +193,8 @@ class CsvDataAdapter {
 					return $this->anyToTimestamp($value);
 				case self::FILTER_TS2DATETIME:
 					return $this->timestampToDatetime($value, "Y-m-d H:i:s");
+				case self::FILTER_TAXONOMY_COMMA:
+					return Sx::x($value)->split(',', true);
 				default:
 					return call_user_func($filter, $value);
 			}


### PR DESCRIPTION
## 問題
city-hc 管理画面（保育連携モバイル 保育施設インポート）で、カンマ区切りのデータの差分抽出ができず、
データの更新ができない場合がある。

## 目的
カンマ区切りの文字列をフィルターで配列に変換する処理を追加したい

## やったこと
 - カンマ区切り形式を追加
 - カンマ区切り形式の場合、カンマ区切りでフィルター配列に追加するようにした

## 手動テスト（どこで、何を、どうしたら、どうなったのか）
 - カンマあり、なしの場合も正しく差分が検出されることを確認した
![スクリーンショット 2021-10-05 15 03 27](https://user-images.githubusercontent.com/39038476/135969120-fd8f8dca-b27c-48a9-abd3-c30550792a4f.png)
![スクリーンショット 2021-10-05 14 59 58](https://user-images.githubusercontent.com/39038476/135969131-f4df0e3a-813f-4e1a-a382-4656a4e2a3d7.png)
 